### PR TITLE
Tolerate overflowing seqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,45 @@ It also has a tool to check if your data structure threw any exceptions when bei
 ;; => [{:exception e :path [:foo]}]
 ```
 
+If you have very big or even infinite lazy seqs, you are going to have a bad
+time realizing them all. By default, Realize will not accept collections with
+more than 10000 items. You can control this limit with the `:max-len` option:
+
+```clj
+(require '[realize.core :as realize])
+
+(def data (map inc (range)))
+
+(realize/realize data {:max-len 1500})
+```
+
+This will produce an exception. Sometimes though, getting the first `n` items of
+infinite seqs are a good compromise. You can tell Realize to chill out and
+behave like `take` by setting `:tolerate-long-seqs?` to `true`:
+
+```clj
+(require '[realize.core :as realize])
+
+(def data (map inc (range)))
+
+(realize/realize data {:max-len 1500
+                       :tolerate-long-seqs? true})
+```
+
+This will recursively prevent any seq in the result from containing more than
+1500 items without throwing exceptions. Seqs that have been truncated this way
+will indicate so in its metadata:
+
+```clj
+(require '[realize.core :as realize])
+
+(def data (map inc (range)))
+
+(meta (realize/realize data {:max-len 1500
+                             :tolerate-long-seqs? true}))
+;;=> {:realize.core/truncated? true}
+```
+
 ## Install
 
 Add `[realize "2019-04-24"]` to `:dependencies` in your `project.clj`.

--- a/test/realize/core_test.clj
+++ b/test/realize/core_test.clj
@@ -58,7 +58,14 @@
 
   (testing "infinite lazy seq"
     (is (= "Sequence of > 500 items found, aborting to guard against infinite seqs!"
-           (.getMessage (:realize.core/exception (sut/realize (range) 500)))))))
+           (.getMessage (:realize.core/exception (sut/realize (range) 500))))))
+
+  (testing "tolerable infinite lazy seq"
+    (is (= ['(0 1 2 3 4)
+            {::sut/truncated? true}]
+           (let [res (sut/realize (range) {:max-len 5
+                                           :tolerate-long-seqs? true})]
+             [res (meta res)])))))
 
 (comment
   (list? (map inc (range))))


### PR DESCRIPTION
By default realize produces an exception when seqs overflow max-items. This commit introduces an option to tolerate overflowing seqs. When `true`, infinite (or just really long) seqs are realized up to `max-len` and come with metadata that indicates that they are truncated.

While I'm certain that this is useful functionality, I'm not particularly married to the API. I considered adding a second function that works like a "taking realize", but couldn't come up with a good signature. This is my best shot, but maybe you have other suggestions for how to achieve the same thing.

(This PR is built on #1 , so maybe check that out first)